### PR TITLE
Add unit tests against mocked test API

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -10,7 +10,7 @@ coverage:
     changes: false
     project:
       default:
-        target: 22.0
+        target: 100.0
         threshold: 0.1
     patch:
       default:

--- a/lib/OpenQA/Wheel/Launcher.pm
+++ b/lib/OpenQA/Wheel/Launcher.pm
@@ -1,7 +1,7 @@
 package OpenQA::Wheel::Launcher;
 use Mojo::Base 'Exporter', -signatures;
 
-use testapi qw(send_key assert_screen check_screen save_screenshot type_string mouse_hide);
+use testapi qw(send_key assert_screen check_screen save_screenshot type_string mouse_hide wait_screen_change);
 
 our @EXPORT_OK = qw(start_gui_program);
 
@@ -31,7 +31,7 @@ needle 'desktop-runner-border' will be required.
 
 =cut
 
-sub start_gui_program ($program, $timeout, %args) {
+sub start_gui_program ($program, $timeout = undef, %args) {
     send_key 'alt-f2';
     mouse_hide(1);
     assert_screen('desktop-runner', $timeout);

--- a/t/01-launcher.t
+++ b/t/01-launcher.t
@@ -1,0 +1,49 @@
+#!/usr/bin/perl
+use Test::Most;
+use Mojo::Base -strict, -signatures;
+
+# import mocked test API
+use FindBin '$Bin';
+use lib "$Bin/lib";
+use testapi;
+
+# import modules we'd like to test
+use lib "$Bin/..", "$Bin/../lib";
+use OpenQA::Wheel::Launcher qw(start_gui_program);
+
+subtest 'run wheel as a whole' => sub {
+    { package tests::wheels::launcher; use tests::wheels::launcher }  # uncoverable statement
+
+    tests::wheels::launcher->new->run;
+    is_deeply testapi::invoked_functions, [
+        [send_key => ('alt-f2')],
+        [mouse_hide => (1)],
+        [assert_screen => ('desktop-runner', undef)],
+        [type_string => ('firefox')],
+        [save_screenshot => ()],
+        [send_key => ('ret')],
+    ], 'expected test API functions invoked' or diag explain testapi::invoked_functions;
+};
+
+subtest 'helper for starting GUI program with custom timeout, terminal and validation' => sub {
+    my $check_screen_invocations = 0;
+    testapi::function_overrides->{check_screen} = sub (@) { ++$check_screen_invocations != 2 };
+    testapi::clear_invoked_functions;
+
+    start_gui_program('foo', 42, valid => 1, terminal => 1);
+    is_deeply testapi::invoked_functions, [
+       [send_key => ('alt-f2')],
+       [mouse_hide => (1)],
+       [assert_screen => ('desktop-runner', 42)],  # timeout passed to assert_screen
+       [type_string => ('foo')],  # program name typed
+       [wait_screen_change => ()],  # due to terminal flag
+       [send_key => ('alt-t')],  # via wait_screen_change callback
+       [save_screenshot => ()],
+       [send_key => ('ret')],
+       [check_screen => ('desktop-runner-border', 2)],  # due to valid flag
+       [send_key => ('ret')],
+       [check_screen => ('desktop-runner-border', 2)],  # no 3rd check_screen call as 2nd invocation mocked to return falsy value
+    ], 'expected test API functions invoked' or diag explain testapi::invoked_functions;
+};
+
+done_testing();

--- a/t/lib/basetest.pm
+++ b/t/lib/basetest.pm
@@ -1,0 +1,4 @@
+package basetest;
+use Mojo::Base -base, -signatures;
+
+1;

--- a/t/lib/testapi.pm
+++ b/t/lib/testapi.pm
@@ -1,0 +1,37 @@
+package testapi;
+use Exporter;
+use Mojo::Base 'Exporter', -signatures;
+
+# list names of test API functions our wheel is expected to call
+our @EXPORT = qw(send_key assert_screen check_screen save_screenshot type_string mouse_hide wait_screen_change);
+
+# define helpers for tracking invoked test API functions
+my @INVOKED;
+my %OVERRIDES;
+sub invoked_functions () { \@INVOKED }
+sub clear_invoked_functions () { @INVOKED = () }
+sub function_overrides () { \%OVERRIDES }
+sub _track_function_call ($function, @args) {
+    push @INVOKED, [$function, @args];
+    return 1 unless my $override = $OVERRIDES{$function};
+    return $override->(@args);
+}
+
+# define test API functions that cannot just be no-ops
+sub wait_screen_change : prototype(&@) {
+    my $callback = shift;
+    _track_function_call wait_screen_change => @_;
+    $callback->();
+}
+
+# use AUTOLOAD to handle remaining test API functions
+sub AUTOLOAD {
+    my $function = our $AUTOLOAD;
+    $function =~ s,.*::,,;
+
+    no strict 'refs';
+    *$AUTOLOAD = sub { _track_function_call($function, @_) };
+    goto &$AUTOLOAD;
+}
+
+1;

--- a/test
+++ b/test
@@ -1,11 +1,27 @@
+# install test-specific dependencies
+set -eo pipefail
+deps=()
+function require_perl_modules() {
+    for module in "$@"; do perl "-M$module" -e1 &> /dev/null || deps+=("perl($module)"); done
+}
 if [[ $WITH_COVER_OPTIONS ]]; then
-    cover_deps=()
-    perl -MDevel::Cover -e1 &> /dev/null || cover_deps+=('perl(Devel::Cover)')
-    perl -MDevel::Cover::Report::Codecovbash -e1 &> /dev/null || cover_deps+=('perl(Devel::Cover::Report::Codecovbash)')
-    [[ $cover_deps ]] && zypper --non-interactive in "${cover_deps[@]}"
+    require_perl_modules Devel::Cover Devel::Cover::Report::Codecovbash
+fi
+require_perl_modules Test::Most
+[[ $deps ]] && zypper --non-interactive in "${deps[@]}"
+
+# configure tracking statement coverage
+if [[ $WITH_COVER_OPTIONS ]]; then
     export PERL5OPT="-I$PWD/t/lib -MDevel::Cover=-db,$PWD/cover_db,-coverage,statement"
 fi
+
+# invoke unit tests
+prove -v
+
+# invoke integration tests
 (isotovideo QEMU_NO_KVM=1 CASEDIR=. SCHEDULE=tests/wheels/launcher _EXIT_AFTER_SCHEDULE=1 ||:) 2>&1 | tee out && grep -q 'Early exit has been requested' out
+
+# upload coverage report to codecov
 if [[ $WITH_COVER_OPTIONS ]]; then
     PERL5OPT= cover -report codecovbash "$PWD/cover_db"
 fi

--- a/tests/wheels/launcher.pm
+++ b/tests/wheels/launcher.pm
@@ -1,6 +1,4 @@
 use Mojo::Base 'basetest';
-# use testapi;
-# use utils;
 use OpenQA::Wheel::Launcher 'start_gui_program';
 
 sub run {


### PR DESCRIPTION
* Add mocked test API and basetest packages
    * Add substitute modules (instead of using `Test::MockModule`) because
      this way we don't have to depend on the original test API modules at
      all
* Fix an error in the signature of `start_gui_program` which would prevent
  tests from passing
* See https://progress.opensuse.org/issues/115022