### PR TITLE
Add support for icewm

### DIFF
--- a/lib/OpenQA/Wheel/Launcher.pm
+++ b/lib/OpenQA/Wheel/Launcher.pm
@@ -1,7 +1,7 @@
 package OpenQA::Wheel::Launcher;
 use Mojo::Base 'Exporter', -signatures;
 
-use testapi qw(send_key assert_screen check_screen save_screenshot type_string mouse_hide wait_screen_change);
+use testapi qw(send_key assert_screen check_var check_screen save_screenshot type_string mouse_hide wait_screen_change);
 
 our @EXPORT_OK = qw(start_gui_program);
 

--- a/lib/OpenQA/Wheel/Launcher.pm
+++ b/lib/OpenQA/Wheel/Launcher.pm
@@ -15,10 +15,9 @@ It is meant to be added to your distribution's wheels.yaml.
 
 =cut
 
-=head1 test API
-
-
 sub desktop_runner_hotkey () { check_var('DESKTOP', 'minimalx') ? 'ctrl-alt-spc' : 'alt-f2' }
+
+=head1 test API
 
 =head2 start_gui_program
 

--- a/lib/OpenQA/Wheel/Launcher.pm
+++ b/lib/OpenQA/Wheel/Launcher.pm
@@ -17,10 +17,13 @@ It is meant to be added to your distribution's wheels.yaml.
 
 =head1 test API
 
+
+sub desktop_runner_hotkey () { check_var('DESKTOP', 'minimalx') ? 'ctrl-alt-spc' : 'alt-f2' }
+
 =head2 start_gui_program
 
-The given program will be launched via the command prompt
-of the desktop environment, assuming it's accessible via F2.
+The given program will be launched via the command prompt of the desktop
+environment with an environment-specific hotkey.
 
 The needle 'desktop-runner' must be matched.
 
@@ -32,7 +35,7 @@ needle 'desktop-runner-border' will be required.
 =cut
 
 sub start_gui_program ($program, $timeout = undef, %args) {
-    send_key 'alt-f2';
+    send_key(desktop_runner_hotkey());
     mouse_hide(1);
     assert_screen('desktop-runner', $timeout);
     type_string $program;

--- a/t/01-launcher.t
+++ b/t/01-launcher.t
@@ -16,7 +16,8 @@ subtest 'run wheel as a whole' => sub {
 
     tests::wheels::launcher->new->run;
     is_deeply testapi::invoked_functions, [
-        [send_key => ('alt-f2')],
+        [check_var => ('DESKTOP', 'minimalx')],
+        [send_key => ('ctrl-alt-spc')],
         [mouse_hide => (1)],
         [assert_screen => ('desktop-runner', undef)],
         [type_string => ('firefox')],
@@ -32,7 +33,8 @@ subtest 'helper for starting GUI program with custom timeout, terminal and valid
 
     start_gui_program('foo', 42, valid => 1, terminal => 1);
     is_deeply testapi::invoked_functions, [
-       [send_key => ('alt-f2')],
+       [check_var => ('DESKTOP', 'minimalx')],
+       [send_key => ('ctrl-alt-spc')],
        [mouse_hide => (1)],
        [assert_screen => ('desktop-runner', 42)],  # timeout passed to assert_screen
        [type_string => ('foo')],  # program name typed

--- a/t/lib/testapi.pm
+++ b/t/lib/testapi.pm
@@ -3,7 +3,7 @@ use Exporter;
 use Mojo::Base 'Exporter', -signatures;
 
 # list names of test API functions our wheel is expected to call
-our @EXPORT = qw(send_key assert_screen check_screen save_screenshot type_string mouse_hide wait_screen_change);
+our @EXPORT = qw(send_key assert_screen check_var check_screen save_screenshot type_string mouse_hide wait_screen_change);
 
 # define helpers for tracking invoked test API functions
 my @INVOKED;


### PR DESCRIPTION
Expanded idea from https://github.com/okurz/os-autoinst-wheel-launcher/tree/feature/icewm_support.

Gnome run: http://dagr.qam.suse.cz/tests/200
Icewm run: http://dagr.qam.suse.cz/tests/199 