### PR TITLE
chore(ci): bump checkout to v6

### DIFF
--- a/.github/workflows/isotovideo.yaml
+++ b/.github/workflows/isotovideo.yaml
@@ -8,7 +8,7 @@ jobs:
     container:
       image: "registry.opensuse.org/devel/openqa/containers-tw/isotovideo:qemu-x86"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Verify the test schedule including wheels
         run: ./test
         env:

--- a/.github/workflows/isotovideo.yaml
+++ b/.github/workflows/isotovideo.yaml
@@ -5,6 +5,8 @@ on: [push, pull_request]
 jobs:
   schedule:
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read
     container:
       image: "registry.opensuse.org/devel/openqa/containers-tw/isotovideo:qemu-x86"
     steps:


### PR DESCRIPTION
This also fixes a warning about outdated nodejs