### PR TITLE
ci: Update Github runner to ubuntu-latest

### DIFF
--- a/.github/workflows/isotovideo.yaml
+++ b/.github/workflows/isotovideo.yaml
@@ -4,7 +4,7 @@ name: isotovideo
 on: [push, pull_request]
 jobs:
   schedule:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     container:

--- a/.github/workflows/isotovideo.yaml
+++ b/.github/workflows/isotovideo.yaml
@@ -10,13 +10,13 @@ jobs:
     container:
       image: "registry.opensuse.org/devel/openqa/containers/isotovideo:qemu-x86"
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Verify the test schedule including wheels
         run: ./test
         env:
           WITH_COVER_OPTIONS: 1
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457  # v3
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           # should not be necessary for public repos, but might help avoid sporadic upload token errors
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
ubuntu-20.04 is not supported anymore

https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/